### PR TITLE
Headers and payloads for 1.1.0

### DIFF
--- a/AASwiftSDK.podspec
+++ b/AASwiftSDK.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |spec|
 
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   spec.name         = "AASwiftSDK"
-  spec.version      = "1.0.1"
+  spec.version      = "1.1.0"
   spec.summary      = "Official AdAdapted iOS Swift SDK"
   spec.description  = <<-DESC
   This SDK allows you to utilize AdAdapted's service platform for displaying ads, keyword intercepts, tracking events, and more.

--- a/AASwiftSDK.xcodeproj/project.pbxproj
+++ b/AASwiftSDK.xcodeproj/project.pbxproj
@@ -982,7 +982,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1.0.1;
+				CURRENT_PROJECT_VERSION = 1.1.0;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -1046,7 +1046,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1.0.1;
+				CURRENT_PROJECT_VERSION = 1.1.0;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -1076,7 +1076,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1.0.1;
+				CURRENT_PROJECT_VERSION = 1.1.0;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = E4LB8UE2WX;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1094,7 +1094,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adadapted.AASwiftSDK;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = NO;
@@ -1112,7 +1112,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1.0.1;
+				CURRENT_PROJECT_VERSION = 1.1.0;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = E4LB8UE2WX;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1130,7 +1130,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adadapted.AASwiftSDK;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = NO;
@@ -1234,7 +1234,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adadapted.ObjCExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "ObjCExampleApp/ObjCExampleApp-Bridging-Header.h";
@@ -1257,7 +1257,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.1;
+				MARKETING_VERSION = 1.1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.adadapted.ObjCExample;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "ObjCExampleApp/ObjCExampleApp-Bridging-Header.h";

--- a/AASwiftSDK.xcodeproj/xcuserdata/bclifton.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/AASwiftSDK.xcodeproj/xcuserdata/bclifton.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -189,7 +189,7 @@
             startingLineNumber = "88"
             endingLineNumber = "88"
             landmarkName = "aaSDKCacheUpdated(_:)"
-            landmarkType = "9">
+            landmarkType = "7">
          </BreakpointContent>
       </BreakpointProxy>
       <BreakpointProxy
@@ -205,7 +205,7 @@
             startingLineNumber = "68"
             endingLineNumber = "68"
             landmarkName = "aaSDKInitComplete(_:)"
-            landmarkType = "9">
+            landmarkType = "7">
          </BreakpointContent>
       </BreakpointProxy>
       <BreakpointProxy
@@ -290,7 +290,7 @@
          BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
          <BreakpointContent
             uuid = "594B7D64-BF48-46C8-B093-5B076341008F"
-            shouldBeEnabled = "Yes"
+            shouldBeEnabled = "No"
             ignoreCount = "0"
             continueAfterRunningActions = "No"
             filePath = "AASwiftSDK/Public/AASDK.swift"
@@ -584,7 +584,7 @@
          BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
          <BreakpointContent
             uuid = "777E223E-7931-4B85-A913-0F4841882FE2"
-            shouldBeEnabled = "Yes"
+            shouldBeEnabled = "No"
             ignoreCount = "0"
             continueAfterRunningActions = "No"
             filePath = "AASwiftSDK/Public/AASDK.swift"
@@ -600,7 +600,7 @@
          BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
          <BreakpointContent
             uuid = "2B1D295B-7095-43B8-8AC7-97D841B5F4DB"
-            shouldBeEnabled = "Yes"
+            shouldBeEnabled = "No"
             ignoreCount = "0"
             continueAfterRunningActions = "No"
             filePath = "AASwiftSDK/Public/AASDK.swift"

--- a/AASwiftSDK.xcodeproj/xcuserdata/bclifton.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/AASwiftSDK.xcodeproj/xcuserdata/bclifton.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -62,8 +62,8 @@
             filePath = "SwiftExampleApp/AppDelegate.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "42"
-            endingLineNumber = "42"
+            startingLineNumber = "43"
+            endingLineNumber = "43"
             landmarkName = "application(_:didFinishLaunchingWithOptions:)"
             landmarkType = "7">
          </BreakpointContent>
@@ -186,10 +186,10 @@
             filePath = "SwiftExampleApp/AppDelegate.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "87"
-            endingLineNumber = "87"
+            startingLineNumber = "88"
+            endingLineNumber = "88"
             landmarkName = "aaSDKCacheUpdated(_:)"
-            landmarkType = "7">
+            landmarkType = "9">
          </BreakpointContent>
       </BreakpointProxy>
       <BreakpointProxy
@@ -202,10 +202,10 @@
             filePath = "SwiftExampleApp/AppDelegate.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "67"
-            endingLineNumber = "67"
+            startingLineNumber = "68"
+            endingLineNumber = "68"
             landmarkName = "aaSDKInitComplete(_:)"
-            landmarkType = "7">
+            landmarkType = "9">
          </BreakpointContent>
       </BreakpointProxy>
       <BreakpointProxy
@@ -218,8 +218,8 @@
             filePath = "AASwiftSDK/Public/AASDK.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "1032"
-            endingLineNumber = "1032"
+            startingLineNumber = "1036"
+            endingLineNumber = "1036"
             landmarkName = "trackImpressionStartedForAllDisplayedImages()"
             landmarkType = "7">
             <Locations>
@@ -296,8 +296,8 @@
             filePath = "AASwiftSDK/Public/AASDK.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "1060"
-            endingLineNumber = "1060"
+            startingLineNumber = "1064"
+            endingLineNumber = "1064"
             landmarkName = "trackImpressionStarted(for:isVisible:)"
             landmarkType = "7">
             <Locations>
@@ -374,8 +374,8 @@
             filePath = "AASwiftSDK/Public/AASDK.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "737"
-            endingLineNumber = "737"
+            startingLineNumber = "741"
+            endingLineNumber = "741"
             landmarkName = "updateTimerFired()"
             landmarkType = "7">
             <Locations>
@@ -454,6 +454,21 @@
                   endingLineNumber = "737"
                   offsetFromSymbolStart = "1949">
                </Location>
+               <Location
+                  uuid = "DCFDEA95-716D-459C-9CCE-CE3DE4893D61 - 92a0ac4b93affc6d"
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "AASwiftSDK.AASDK.updateTimerFired() -&gt; ()"
+                  moduleName = "AASwiftSDK"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/bclifton/Documents/GitHub/ios-swift-sdk/AASwiftSDK/Public/AASDK.swift"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "741"
+                  endingLineNumber = "741"
+                  offsetFromSymbolStart = "1949">
+               </Location>
             </Locations>
          </BreakpointContent>
       </BreakpointProxy>
@@ -467,8 +482,8 @@
             filePath = "AASwiftSDK/Public/AASDK.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "671"
-            endingLineNumber = "671"
+            startingLineNumber = "675"
+            endingLineNumber = "675"
             landmarkName = "coming(toForeground:)"
             landmarkType = "7">
             <Locations>
@@ -547,7 +562,70 @@
                   endingLineNumber = "671"
                   offsetFromSymbolStart = "3154">
                </Location>
+               <Location
+                  uuid = "B1B3689C-EEC6-4AE4-BC24-AF3275209A87 - cb2bec771a6aca34"
+                  shouldBeEnabled = "Yes"
+                  ignoreCount = "0"
+                  continueAfterRunningActions = "No"
+                  symbolName = "AASwiftSDK.AASDK.coming(toForeground: Swift.Optional&lt;Foundation.Notification&gt;) -&gt; ()"
+                  moduleName = "AASwiftSDK"
+                  usesParentBreakpointCondition = "Yes"
+                  urlString = "file:///Users/bclifton/Documents/GitHub/ios-swift-sdk/AASwiftSDK/Public/AASDK.swift"
+                  startingColumnNumber = "9223372036854775807"
+                  endingColumnNumber = "9223372036854775807"
+                  startingLineNumber = "675"
+                  endingLineNumber = "675"
+                  offsetFromSymbolStart = "3154">
+               </Location>
             </Locations>
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "777E223E-7931-4B85-A913-0F4841882FE2"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "AASwiftSDK/Public/AASDK.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "453"
+            endingLineNumber = "453"
+            landmarkName = "privateStartSession(withAppID:registerListenersFor:options:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "2B1D295B-7095-43B8-8AC7-97D841B5F4DB"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "AASwiftSDK/Public/AASDK.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "1291"
+            endingLineNumber = "1291"
+            landmarkName = "checkForPayloads()"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "37F87839-E289-4E93-B76A-36709496B3AD"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "AASwiftSDK/Public/AASDK.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "1292"
+            endingLineNumber = "1292"
+            landmarkName = "checkForPayloads()"
+            landmarkType = "7">
          </BreakpointContent>
       </BreakpointProxy>
    </Breakpoints>

--- a/AASwiftSDK/Connection/AAConnector.swift
+++ b/AASwiftSDK/Connection/AAConnector.swift
@@ -159,6 +159,7 @@ class AAConnector: NSObject, URLSessionDelegate {
             request = URLRequest(url: url)
         }
         request?.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request?.setValue(appID, forHTTPHeaderField: "X-API-KEY")
         request?.httpMethod = methodType ?? ""
         request?.httpBody = jsonMessage
         

--- a/AASwiftSDK/Public/AAHelper.swift
+++ b/AASwiftSDK/Public/AAHelper.swift
@@ -178,11 +178,11 @@ var _screenSize = CGSize.zero
 
 class AAHelper: NSObject {
     class func sdkVersion() -> String {
-        return "1.0.1"
+        return "1.1.0"
     }
 
     class func bundleVersion() -> String {
-        return "1.0.1"
+        return "1.1.0"
     }
 
     class func bundleID() -> String {

--- a/AASwiftSDK/Public/AASDK.swift
+++ b/AASwiftSDK/Public/AASDK.swift
@@ -23,6 +23,7 @@ var _customId: String?
 @objc public class AASDK: NSObject {
     @objc public static let OPTION_TEST_MODE = "TEST_MODE"
     @objc public static let OPTION_KEYWORD_INTERCEPT = "KEYWORD_INTERCEPT"
+    @objc public static let OPTION_EXTERNAL_PAYLOADS = "EXTERNAL_PAYLOADS"
     @objc public static let OPTION_CUSTOM_ID = "CUSTOM_ID"
     @objc public static let KEY_CONTENT_PAYLOADS = "CONTENT_PAYLOADS"
     @objc public static let KEY_AD_CONTENT = "AD_CONTENT"
@@ -72,6 +73,7 @@ var _customId: String?
     private var deviceLocation: CLLocation?
     private var unloadAdAfterOne = false
     private var isKeywordInterceptOn = false
+    private var isPayloadEnabled = false
     private var kiManager: AAKeywordInterceptManager?
     private var impressionCounters: [AnyHashable: Any]?
     private var payloadTrackers: [AnyHashable: Any]?
@@ -345,6 +347,7 @@ var _customId: String?
             _currentState = .kUninitialized
             _aasdk?.disableAdvertising = false
             _aasdk?.isKeywordInterceptOn = false
+            _aasdk?.isPayloadEnabled = false
             _aasdk?.serverRoot = AA_PROD_ROOT
             _aasdk?.serverVersion = AA_API_VERSION
             _aasdk?.payloadTrackers = [AnyHashable : Any](minimumCapacity: 0)
@@ -447,6 +450,7 @@ var _customId: String?
             }
 
             _aasdk?.isKeywordInterceptOn = (opDic?[OPTION_KEYWORD_INTERCEPT] ?? false) as! Bool
+            _aasdk?.isPayloadEnabled = (opDic?[OPTION_EXTERNAL_PAYLOADS] ?? false) as! Bool
             _aasdk?.appInitParams = opDic?[AASDK_OPTION_INIT_PARAMS] as? [AnyHashable : Any]
         }
 
@@ -1284,7 +1288,7 @@ extension AASDK {
 
 // MARK: - Internal NSNotificationCenter
     class func checkForPayloads() {
-        if _aasdk?.lastPayloadCheck != nil && (abs(Int(_aasdk?.lastPayloadCheck?.timeIntervalSinceNow ?? 0)) < Int(minPayloadIntervalSec)) {
+        if _aasdk?.lastPayloadCheck != nil && _aasdk?.isPayloadEnabled == false && (abs(Int(_aasdk?.lastPayloadCheck?.timeIntervalSinceNow ?? 0)) < Int(minPayloadIntervalSec)) {
             return
         }
         _aasdk?.lastPayloadCheck = Date()

--- a/SwiftExampleApp/AppDelegate.swift
+++ b/SwiftExampleApp/AppDelegate.swift
@@ -20,6 +20,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, AASDKObserver, AASDKDebug
         let options = [
             AASDK.OPTION_TEST_MODE:true,
             AASDK.OPTION_KEYWORD_INTERCEPT:true,
+            AASDK.OPTION_EXTERNAL_PAYLOADS:true,
             AASDK.OPTION_CUSTOM_ID:"CustomIdTest::\(Int.random(in: 100..<999))"]
             as [String : Any]
 

--- a/SwiftExampleApp/Info.plist
+++ b/SwiftExampleApp/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.1</string>
+	<string>1.1.0</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.1</string>
+	<string>1.1.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSUserTrackingUsageDescription</key>


### PR DESCRIPTION
This new version bump includes changes to append new headers for back end filtration as well as updates to our logic that refreshes stale ads. This also includes a new manual flag to enable or disable the retrieval of external payloads.