### PR TITLE
Updating to 1.3.7 for event deduplication and cfbundle change

### DIFF
--- a/AASwiftSDK.podspec
+++ b/AASwiftSDK.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |spec|
 
   # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   spec.name         = "AASwiftSDK"
-  spec.version      = "1.3.6"
+  spec.version      = "1.3.7"
   spec.summary      = "Official AdAdapted iOS Swift Interop SDK"
   spec.description  = <<-DESC
   This SDK allows you to utilize AdAdapted's service platform for displaying ads, keyword intercepts, tracking events, and more.

--- a/AASwiftSDK.xcodeproj/xcuserdata/bclifton.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/AASwiftSDK.xcodeproj/xcuserdata/bclifton.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -40,7 +40,7 @@
          BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
          <BreakpointContent
             uuid = "BAA6D050-2827-451B-90B1-4C7B974233F9"
-            shouldBeEnabled = "Yes"
+            shouldBeEnabled = "No"
             ignoreCount = "0"
             continueAfterRunningActions = "No"
             filePath = "AASwiftSDK/AdObjects/AAAdAdaptedAdProvider.swift"
@@ -56,7 +56,7 @@
          BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
          <BreakpointContent
             uuid = "66983DB5-BCA0-4B0B-BE18-DE6109D01BE8"
-            shouldBeEnabled = "Yes"
+            shouldBeEnabled = "No"
             ignoreCount = "0"
             continueAfterRunningActions = "No"
             filePath = "AASwiftSDK/AdObjects/AAWebAdView.swift"
@@ -72,7 +72,7 @@
          BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
          <BreakpointContent
             uuid = "CEF2CA6D-6049-4946-B98C-2E355895900E"
-            shouldBeEnabled = "Yes"
+            shouldBeEnabled = "No"
             ignoreCount = "0"
             continueAfterRunningActions = "No"
             filePath = "AASwiftSDK/AdObjects/Popup/AAPopupView.swift"
@@ -88,7 +88,7 @@
          BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
          <BreakpointContent
             uuid = "2A859924-CC8D-47BC-8783-7DA93BE7F2C0"
-            shouldBeEnabled = "Yes"
+            shouldBeEnabled = "No"
             ignoreCount = "0"
             continueAfterRunningActions = "No"
             filePath = "AASwiftSDK/AdObjects/AAAdAdaptedAdProvider.swift"
@@ -103,16 +103,96 @@
       <BreakpointProxy
          BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
          <BreakpointContent
-            uuid = "FA679A88-B12A-4F01-A0E3-6A999E39CD2C"
-            shouldBeEnabled = "Yes"
+            uuid = "BC8C8123-A157-4A96-A0AD-A129F6107BBA"
+            shouldBeEnabled = "No"
             ignoreCount = "0"
             continueAfterRunningActions = "No"
-            filePath = "AASwiftSDK/Public/AAZoneView.swift"
+            filePath = "AASwiftSDK/AdObjects/AAAdAdaptedAdProvider.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "38"
-            endingLineNumber = "38"
-            landmarkName = "init(frame:forZone:zoneType:delegate:isVisible:)"
+            startingLineNumber = "195"
+            endingLineNumber = "195"
+            landmarkName = "renderNextForceReload(_:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "01AD8F54-A3CA-434B-9C46-4CCF00A5A36F"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "AASwiftSDK/AdObjects/AAAdAdaptedAdProvider.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "138"
+            endingLineNumber = "138"
+            landmarkName = "renderNextForceReload(_:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "18D6A4A8-6472-4570-BD5A-861D72623BD0"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "AASwiftSDK/AdObjects/AAAdAdaptedAdProvider.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "160"
+            endingLineNumber = "160"
+            landmarkName = "renderNextForceReload(_:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "96A60849-6513-45AF-953B-51B4BB132405"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "AASwiftSDK/AdObjects/AAAdAdaptedAdProvider.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "162"
+            endingLineNumber = "162"
+            landmarkName = "renderNextForceReload(_:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "308137EC-D9BB-4878-A643-597EAEB0C4F4"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "AASwiftSDK/AdObjects/AAAdAdaptedAdProvider.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "186"
+            endingLineNumber = "186"
+            landmarkName = "renderNextForceReload(_:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "728C7005-AA18-4317-8786-999505B9D7CB"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "AASwiftSDK/AdObjects/AAAdAdaptedAdProvider.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "202"
+            endingLineNumber = "202"
+            landmarkName = "renderNextForceReload(_:)"
             landmarkType = "7">
          </BreakpointContent>
       </BreakpointProxy>

--- a/AASwiftSDK/Connection/AAConnector.swift
+++ b/AASwiftSDK/Connection/AAConnector.swift
@@ -18,10 +18,10 @@ class AAConnector: NSObject, URLSessionDelegate {
     private var appID: String?
     private var sessionID: String?
     private var immediateQueue = Queue<AARequestBlockHolder>()
-    private var events = [AnyHashable]()
-    private var eventsV2 = [AnyHashable]()
-    private var collectableEvents = [AnyHashable]()
-    private var collectableErrorEvents = [AnyHashable]()
+    private var events: Set<AnyHashable> = []
+    private var eventsV2: Set<AnyHashable> = []
+    private var collectableEvents: Set<AnyHashable> = []
+    private var collectableErrorEvents: Set<AnyHashable> = []
     private var backgroundUpdateTask: UIBackgroundTaskIdentifier! = .invalid
     private var timer: Timer?
     private var session: URLSession?
@@ -61,7 +61,7 @@ class AAConnector: NSObject, URLSessionDelegate {
 
     func addEvent(forBatchDispatch event: AAReportableSessionEvent?) {
         if let event = event {
-            events.append(event)
+            events.insert(event)
         }
     }
 
@@ -75,19 +75,19 @@ class AAConnector: NSObject, URLSessionDelegate {
         }
 
         if let event = event {
-            eventsV2.append(event)
+            eventsV2.insert(event)
         }
     }
 
     func addCollectableEvent(forDispatch event: AACollectableEvent?) {
         if let event = event {
-            collectableEvents.append(event)
+            collectableEvents.insert(event)
         }
     }
 
     func addCollectableError(forDispatch event: AACollectableError?) {
         if let event = event {
-            collectableErrorEvents.append(event)
+            collectableErrorEvents.insert(event)
         }
     }
 

--- a/AASwiftSDK/Public/AAHelper.swift
+++ b/AASwiftSDK/Public/AAHelper.swift
@@ -187,7 +187,7 @@ class AAHelper: NSObject {
     }
 
     class func bundleVersion() -> String {
-        return Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? ""
+        return Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? ""
     }
 
     class func bundleID() -> String {

--- a/AASwiftSDK/Public/AAHelper.swift
+++ b/AASwiftSDK/Public/AAHelper.swift
@@ -183,7 +183,7 @@ var _screenSize = CGSize.zero
 
 class AAHelper: NSObject {
     class func sdkVersion() -> String {
-        return "1.3.6"
+        return "1.3.7"
     }
 
     class func bundleVersion() -> String {

--- a/AASwiftSDK/Requests/EventCollector/AACollectableErrorRequest.swift
+++ b/AASwiftSDK/Requests/EventCollector/AACollectableErrorRequest.swift
@@ -9,7 +9,7 @@ import Foundation
 
 @objcMembers
 class AACollectableErrorRequest: AAGenericRequest {
-    init(events: [AnyHashable]?) {
+    init(events: Set<AnyHashable>?) {
         super.init()
         if let events = events {
             self.events = events
@@ -41,7 +41,7 @@ class AACollectableErrorRequest: AAGenericRequest {
         }
     }
 
-    private var events: [AnyHashable]?
+    private var events: Set<AnyHashable>?
 
     override func asJSON() -> String? {
         if let bytes = asData() {

--- a/AASwiftSDK/Requests/EventCollector/AACollectableEventRequest.swift
+++ b/AASwiftSDK/Requests/EventCollector/AACollectableEventRequest.swift
@@ -10,7 +10,7 @@ import Foundation
 
 @objcMembers
 class AACollectableEventRequest: AAGenericRequest {
-    init(events: [AnyHashable]?) {
+    init(events: Set<AnyHashable>?) {
         super.init()
         if let events = events {
             self.events = events
@@ -42,7 +42,7 @@ class AACollectableEventRequest: AAGenericRequest {
         }
     }
     
-    private var events: [AnyHashable]?
+    private var events: Set<AnyHashable>?
     
     override func asJSON() -> String? {
         if let data = asData() {

--- a/AASwiftSDK/Requests/TrackEvent/AABatchEventRequest.swift
+++ b/AASwiftSDK/Requests/TrackEvent/AABatchEventRequest.swift
@@ -11,7 +11,7 @@ import Foundation
 class AABatchEventRequest: AAGenericRequest {
     private var version = 0
     
-    init(events: [AnyHashable]?, forVersion version: Int) {
+    init(events: Set<AnyHashable>?, forVersion version: Int) {
         super.init()
         self.version = version
         var dics: [Any] = []
@@ -29,7 +29,7 @@ class AABatchEventRequest: AAGenericRequest {
         setParamValue(dics as NSObject, forKey: "events")
     }
     
-    convenience init(events: [AnyHashable]?) {
+    convenience init(events: Set<AnyHashable>?) {
         self.init(events: events, forVersion: 1)
     }
 

--- a/ObjCExampleApp/Info.plist
+++ b/ObjCExampleApp/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.6</string>
+	<string>1.3.7</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/SwiftExampleApp/AppDelegate.swift
+++ b/SwiftExampleApp/AppDelegate.swift
@@ -19,8 +19,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, AASDKObserver, AASDKDebug
         let options = [
             AASDK.OPTION_TEST_MODE:true,
             AASDK.OPTION_KEYWORD_INTERCEPT:true,
-            AASDK.OPTION_EXTERNAL_PAYLOADS:true]
-            //AASDK.OPTION_CUSTOM_ID:"CustomIdTest::112"]
+            AASDK.OPTION_EXTERNAL_PAYLOADS:true,
+            AASDK.OPTION_CUSTOM_ID:"SwiftLegacyTestApp"]
             as [String : Any]
 
          // iOS api key

--- a/SwiftExampleApp/Info.plist
+++ b/SwiftExampleApp/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.6</string>
+	<string>1.3.7</string>
 	<key>CFBundleVersion</key>
 	<string>swiftSample</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/SwiftExampleApp/OffScreenAdController.swift
+++ b/SwiftExampleApp/OffScreenAdController.swift
@@ -13,18 +13,21 @@ class OffScreenAdContoller: UIViewController, UIScrollViewDelegate, AAZoneViewOw
 
     @IBOutlet weak var offScreenScrollView: UIScrollView!
     @IBOutlet weak var offScreenZoneView: AdAdaptedZoneView!
+    var manualCreation: AdAdaptedZoneView!
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
 //        manual creation
-//        let manualCreation = AdAdaptedZoneView(frame: .zero, forZone: "zoneID", delegate: self, isVisible: false)
-//        manualCreation.setAdZoneContext(contextID: "organic")
-//        manualCreation.setAdZoneVisibility(isViewable: true)
+        //manualCreation = AdAdaptedZoneView(frame: .init(x: 0, y: 0, width: 350, height: 100), forZone: "102110", delegate: self, isVisible: false)
+        //manualCreation.setAdZoneContext(contextID: "organic")
+        //manualCreation.setAdZoneVisibility(isViewable: true)
         
         offScreenZoneView.setAdZoneVisibility(isViewable: false)
         offScreenScrollView.delegate = self
         offScreenZoneView.setZoneOwner(self)
+        
+        //offScreenScrollView.addSubview(manualCreation)
     }
 
     func viewControllerForPresentingModalView() -> UIViewController? {


### PR DESCRIPTION
- Events now use sets instead of arrays for deduplication
- Bundle version has been set to CFBundleShortVersionString