### PR TITLE
Potential fix for code scanning alert no. 2: Cleartext logging of sensitive information

### DIFF
--- a/AASwiftSDK/Public/AASDK.swift
+++ b/AASwiftSDK/Public/AASDK.swift
@@ -173,7 +173,7 @@ var _customId: String?
 
     class func setDeviceLocation(_ location: CLLocation?) {
         if let location = location {
-            AASDK.logDebugMessage("AASDK location set \(location.coordinate.latitude) \(location.coordinate.longitude)", type: DEBUG_GENERAL)
+            AASDK.logDebugMessage("AASDK location set successfully", type: DEBUG_GENERAL)
             _aasdk?.deviceLocation = location
         } else {
             AASDK.logDebugMessage("Location set to nil", type: DEBUG_GENERAL)


### PR DESCRIPTION
Potential fix for [https://github.com/adadaptedinc/ios-swift-sdk/security/code-scanning/2](https://github.com/adadaptedinc/ios-swift-sdk/security/code-scanning/2)

To fix the issue, we should avoid logging sensitive geolocation data in cleartext. Instead, we can either obfuscate the data or omit it entirely from the log message. Since the latitude and longitude values are sensitive, the best approach is to remove them from the log message. This ensures compliance with privacy standards and eliminates the risk of exposing sensitive information.

The changes will be made in the `setDeviceLocation` method, specifically on line 176. The log message will be updated to exclude the latitude and longitude values.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
